### PR TITLE
some e2e tests for diskrsync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ######################################################################
 # Establish a common builder image for all golang-based images
-FROM docker.io/library/golang:1.19 AS golang-builder
+FROM golang:1.19 AS golang-builder
 USER root
 WORKDIR /workspace
 # We don't vendor modules. Enforce that behavior
@@ -82,7 +82,7 @@ RUN go run build.go -no-upgrade
 FROM golang-builder AS diskrsync-builder
 
 WORKDIR /workspace/diskrsync
-RUN GOPATH=$(pwd) go install github.com/dop251/diskrsync/diskrsync@latest
+RUN GOPATH=$(pwd) go install github.com/dop251/diskrsync/diskrsync@v1.3.0
 
 ######################################################################
 # Build diskrsync-tcp binary

--- a/controllers/mover/rsynctls/logfilter.go
+++ b/controllers/mover/rsynctls/logfilter.go
@@ -24,10 +24,11 @@ import (
 var rsyncTLSRegex = regexp.MustCompile(
 	`([sS]ent)\s.+([bB]ytes)\s.+([rR]eceived)\s.+([bB]ytes)|` +
 		`([tT]otal size)|` +
-		`^\s*([rR]sync completed in)`)
+		`([rR]sync completed in)`)
 
 var rsyncTLSRegexFailures = regexp.MustCompile(
 	`^\s*([rR]sync)|` +
+		`^\s*(disk[rR]sync)|` +
 		`([fF]ail)|` +
 		`([eE]rror)`)
 

--- a/mover-rsync-tls/client.sh
+++ b/mover-rsync-tls/client.sh
@@ -35,6 +35,8 @@ if [[ ! -d $SOURCE ]] && ! test -b $BLOCK_SOURCE; then
 fi
 
 if ! test -b $BLOCK_SOURCE; then
+    echo "Source PVC volumeMode is filesystem"
+
     cat - > "$STUNNEL_CONF" <<STUNNEL_CONF
 ; Global options
 debug = debug
@@ -57,6 +59,8 @@ STUNNEL_CONF
 ## Print version information
 rsync --version
 else
+    echo "Source PVC volumeMode is block"
+
     cat - > "$STUNNEL_CONF" <<STUNNEL_CONF
 ; Global options
 debug = debug

--- a/mover-rsync-tls/server.sh
+++ b/mover-rsync-tls/server.sh
@@ -30,6 +30,7 @@ fi
 if [[ -d $TARGET ]]; then
     ##############################
     ## Filesystem volume, use rsync
+    echo "Destination PVC volumeMode is filesystem"
 
     mkdir -p "$(dirname "$CONTROL_FILE")"
 
@@ -107,6 +108,7 @@ fi
 if test -b $BLOCK_TARGET; then
     ##############################
     ## block volume, use diskrsync-tcp
+    echo "Destination PVC volumeMode is block"
 
     ##############################
     ## Set up stunnel config
@@ -129,9 +131,9 @@ connect = 8888
 #exec = /diskrsync-tcp
 #execargs = diskrsync-tcp $BLOCK_TARGET --target --port 8888 --control-file $CONTROL_FILE
 STUNNEL_CONF
-fi
 
-/diskrsync-tcp $BLOCK_TARGET --target --port 8888 --control-file $CONTROL_FILE&
+  /diskrsync-tcp $BLOCK_TARGET --target --port 8888 --control-file $CONTROL_FILE&
+fi
 
 ##############################
 ## Start stunnel to wait for incoming connections

--- a/mover-rsync/destination.sh
+++ b/mover-rsync/destination.sh
@@ -9,6 +9,12 @@ mkdir -p ~/.ssh
 chmod 700 ~/.ssh
 echo "command=\"/mover-rsync/destination-command.sh\",restrict $(</keys/source.pub)" > ~/.ssh/authorized_keys
 
+VOLUME_MODE="filesystem"
+if test -b /dev/block; then
+    VOLUME_MODE=block
+fi
+echo "Destination PVC volumeMode is $VOLUME_MODE"
+
 # Wait for incoming rsync transfer
 echo "Waiting for connection..."
 rm -f /var/run/nologin

--- a/mover-rsync/source.sh
+++ b/mover-rsync/source.sh
@@ -18,6 +18,12 @@ if [[ ! -d $SOURCE ]] && ! test -b $BLOCK_SOURCE; then
     exit 1
 fi
 
+VOLUME_MODE="filesystem"
+if test -b $BLOCK_SOURCE; then
+    VOLUME_MODE=block
+fi
+echo "Source PVC volumeMode is $VOLUME_MODE"
+
 mkdir -p ~/.ssh/controlmasters
 chmod 711 ~/.ssh
 

--- a/test-e2e/roles/compare_pvc_data_block/meta/main.yml
+++ b/test-e2e/roles/compare_pvc_data_block/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - role: gather_cluster_info

--- a/test-e2e/roles/compare_pvc_data_block/tasks/main.yml
+++ b/test-e2e/roles/compare_pvc_data_block/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+
+- name: Check for required variables
+  fail: msg="Variable {{ var_check }} must be defined to use this role"
+  when: vars[var_check] is undefined
+  with_items:
+    - namespace
+    - pvc1_name
+    - pvc2_name
+  loop_control:
+    loop_var: var_check
+
+- name: Determine whether the check should fail
+  ansible.builtin.set_fact:
+    local_should_fail: "{{ should_fail | default(false) }}"
+
+- name: Create Job
+  kubernetes.core.k8s:
+    state: present
+    template: job.yml.j2
+  register: res
+
+- block:
+    - name: Wait for compare to complete
+      kubernetes.core.k8s_info:
+        api_version: batch/v1
+        kind: Job
+        name: "{{ res.result.metadata.name }}"
+        namespace: "{{ namespace }}"
+      register: res2
+      # We wait until we either get a job success or a failure
+      until: >
+        res2.resources | length > 0 and
+        ( ( res2.resources[0].status.succeeded is defined and
+            res2.resources[0].status.succeeded == 1 )
+          or
+          ( res2.resources[0].status.failed is defined and
+            res2.resources[0].status.failed == 1 )
+        )
+      delay: 1
+      retries: "{{ timeout | default(300) }}"
+
+    - name: Determine whether result was expected
+      fail:
+        msg: "Unexpected comparison result"
+      when: >
+        ( local_should_fail and
+          res2.resources[0].status.succeeded is defined and
+          res2.resources[0].status.succeeded > 0 )
+        or
+        ( not local_should_fail and
+          res2.resources[0].status.failed is defined and
+          res2.resources[0].status.failed > 0 )
+  always:
+    - name: Retrieve logs from Job
+      kubernetes.core.k8s_log:
+        api_version: batch/v1
+        kind: Job
+        name: "{{ res.result.metadata.name }}"
+        namespace: "{{ namespace }}"
+      register: log
+
+    - name: Dump Job log
+      debug:
+        var: log.log_lines
+
+- name: Delete Job
+  kubernetes.core.k8s:
+    state: absent
+    api_version: batch/v1
+    kind: Job
+    name: "{{ res.result.metadata.name }}"
+    namespace: "{{ namespace }}"
+    delete_options:
+      propagationPolicy: "Background"

--- a/test-e2e/roles/compare_pvc_data_block/templates/job.yml.j2
+++ b/test-e2e/roles/compare_pvc_data_block/templates/job.yml.j2
@@ -1,0 +1,67 @@
+---
+
+kind: Job
+apiVersion: batch/v1
+metadata:
+  generateName: compare-pvcs-
+  namespace: "{{ namespace }}"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 0
+  template:
+    spec:
+      containers:
+        - name: busybox
+          image: gcr.io/distroless/static:debug
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -e -o pipefail
+
+              id
+
+              # Read 50 512-byte blocks from both PVCs
+              dd if=/dev/block1 bs=512 count=50 of=/tmp/pvc1
+              dd if=/dev/block2 bs=512 count=50 of=/tmp/pvc2
+
+              echo "Validating block contents: PVC1 -> PVC2"
+              sha256sum -b /tmp/pvc1 | \
+                sed 's|pvc1|pvc2|g' | \
+                sha256sum -c
+
+              echo "Validating contents: PVC2 -> PVC1"
+              sha256sum -b /tmp/pvc2 | \
+                sed 's|pvc2|pvc1|g' | \
+                sha256sum -c
+
+              echo "... file contents matched"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: "/tmp"
+          volumeDevices:
+            - name: pvc1
+              devicePath: "/dev/block1"
+            - name: pvc2
+              devicePath: "/dev/block2"
+      restartPolicy: Never
+{% if podSecurityContext is defined %}
+      securityContext: {{ podSecurityContext }}
+{% endif %}
+      terminationGracePeriodSeconds: 2
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+        - name: pvc1
+          persistentVolumeClaim:
+            claimName: "{{ pvc1_name }}"
+        - name: pvc2
+          persistentVolumeClaim:
+            claimName: "{{ pvc2_name }}"

--- a/test-e2e/roles/write_to_pvc_block/meta/main.yml
+++ b/test-e2e/roles/write_to_pvc_block/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - role: gather_cluster_info

--- a/test-e2e/roles/write_to_pvc_block/tasks/main.yml
+++ b/test-e2e/roles/write_to_pvc_block/tasks/main.yml
@@ -1,0 +1,55 @@
+---
+
+- name: Check for required variables
+  fail: msg="Variable {{ var_check }} must be defined to use this role"
+  when: vars[var_check] is undefined
+  with_items:
+    - data
+    - pvc_name
+    - namespace
+  loop_control:
+    loop_var: var_check
+
+- name: Create Job
+  kubernetes.core.k8s:
+    state: present
+    template: job.yml.j2
+  register: res
+
+- block:
+    - name: Wait for Job to complete
+      kubernetes.core.k8s_info:
+        api_version: batch/v1
+        kind: Job
+        name: "{{ res.result.metadata.name }}"
+        namespace: "{{ namespace }}"
+      register: res2
+      until: >
+        res2.resources | length > 0 and
+        res2.resources[0].status.succeeded is defined and
+        res2.resources[0].status.succeeded==1
+      delay: 1
+      retries: "{{ timeout | default(300) }}"
+
+  always:
+    - name: Retrieve logs from Job
+      kubernetes.core.k8s_log:
+        api_version: batch/v1
+        kind: Job
+        name: "{{ res.result.metadata.name }}"
+        namespace: "{{ namespace }}"
+      register: log
+
+    - name: Dump Job log
+      debug:
+        var: log.log_lines
+
+- name: Delete Job
+  kubernetes.core.k8s:
+    state: absent
+    api_version: batch/v1
+    kind: Job
+    name: "{{ res.result.metadata.name }}"
+    namespace: "{{ namespace }}"
+    delete_options:
+      propagationPolicy: "Background"

--- a/test-e2e/roles/write_to_pvc_block/templates/job.yml.j2
+++ b/test-e2e/roles/write_to_pvc_block/templates/job.yml.j2
@@ -1,0 +1,47 @@
+---
+
+kind: Job
+apiVersion: batch/v1
+metadata:
+  generateName: writer-
+  namespace: "{{ namespace }}"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 6
+  template:
+    spec:
+      containers:
+        - name: busybox
+          image: gcr.io/distroless/static:debug
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -x -e -o pipefail
+
+              id
+
+              ls -al /dev/block
+
+              # Using blocksize 512, writing 2 blocks - all zeros, start 48 blocks in
+              # write data (will not write anything more than 2x512 bytes)
+              echo '{{ data }}' | dd bs=512 count=2 seek=48 of=/dev/block
+              sync
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          volumeDevices:
+            - name: pvc
+              devicePath: "/dev/block"
+      restartPolicy: Never
+{% if podSecurityContext is defined %}
+      securityContext: {{ podSecurityContext }}
+{% endif %}
+      terminationGracePeriodSeconds: 2
+      volumes:
+        - name: pvc
+          persistentVolumeClaim:
+            claimName: "{{ pvc_name }}"

--- a/test-e2e/test_rsync_tls_normal_diskrsync.yml
+++ b/test-e2e/test_rsync_tls_normal_diskrsync.yml
@@ -1,0 +1,247 @@
+---
+- hosts: localhost
+  tags:
+    - e2e
+    - rsync_tls
+    - diskrsync
+    - block
+    - unprivileged
+    - volumepopulator
+  tasks:
+    - name: Create namespace
+      include_role:
+        name: create_namespace
+
+    - name: Probe cluster information
+      include_role:
+        name: gather_cluster_info
+
+    - name: Define podSecurityContext
+      ansible.builtin.set_fact:
+        podSecurityContext:
+          fsGroup: 5678
+          runAsGroup: 5678
+          #fsGroup: 6
+          #runAsGroup: 6
+          runAsNonRoot: true
+          runAsUser: 1234
+          seccompProfile:
+            type: RuntimeDefault
+      when: not cluster_info.is_openshift
+
+    - name: Create dest block PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-dest-temp
+            namespace: "{{ namespace }}"
+          spec:
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Create ReplicationDestination (w/ mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: test
+            namespace: "{{ namespace }}"
+          spec:
+            rsyncTLS:
+              destinationPVC: data-dest-temp
+              copyMethod: Snapshot
+              capacity: 1Gi
+              accessModes:
+                - ReadWriteOnce
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Create ReplicationDestination (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: test
+            namespace: "{{ namespace }}"
+          spec:
+            rsyncTLS:
+              destinationPVC: data-dest-temp
+              copyMethod: Snapshot
+              capacity: 1Gi
+              accessModes:
+                - ReadWriteOnce
+      when: podSecurityContext is not defined
+
+    - name: Create source block PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-source
+            namespace: "{{ namespace }}"
+          spec:
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Write data into the source block PVC
+      include_role:
+        name: write_to_pvc_block
+      vars:
+        data: 'data'
+        pvc_name: 'data-source'
+
+    - name: Wait for key and address to be ready
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: test
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.rsyncTLS is defined and
+        res.resources[0].status.rsyncTLS.keySecret is defined and
+        res.resources[0].status.rsyncTLS.address is defined
+      delay: 1
+      retries: 300
+
+    - name: Create ReplicationSource (w/ mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              schedule: "0 0 1 1 *"
+            rsyncTLS:
+              keySecret: "{{ res.resources[0].status.rsyncTLS.keySecret }}"
+              address: "{{ res.resources[0].status.rsyncTLS.address }}"
+              copyMethod: Snapshot
+              moverSecurityContext: "{{ podSecurityContext }}"
+      when: podSecurityContext is defined
+
+    - name: Create ReplicationSource (w/o mSC)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              schedule: "0 0 1 1 *"
+            rsyncTLS:
+              keySecret: "{{ res.resources[0].status.rsyncTLS.keySecret }}"
+              address: "{{ res.resources[0].status.rsyncTLS.address }}"
+              copyMethod: Snapshot
+      when: podSecurityContext is not defined
+
+    - name: Check status of replicationsource
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationSource
+        name: source
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastSyncDuration is defined and
+        res.resources[0].status.lastSyncTime is defined and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful" and
+        res.resources[0].status.latestMoverStatus.logs is search("diskrsync completed in.*")
+      delay: 1
+      retries: 900
+
+    - name: Wait for sync to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: test
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.latestImage is defined and
+        res.resources[0].status.latestImage.kind == "VolumeSnapshot" and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful"
+      delay: 1
+      retries: 900
+
+    - name: Convert latestImage to block PVC using VolumePopulator
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: data-dest
+            namespace: "{{ namespace }}"
+          spec:
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+            dataSourceRef:
+              kind: ReplicationDestination
+              apiGroup: volsync.backube
+              name: test
+            resources:
+              requests:
+                storage: 1Gi
+      when: cluster_info.volumepopulator_supported
+
+    - name: Convert latestImage to block PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: data-dest
+            namespace: "{{ namespace }}"
+          spec:
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+            dataSource:
+              kind: VolumeSnapshot
+              apiGroup: snapshot.storage.k8s.io
+              name: "{{ res.resources[0].status.latestImage.name }}"
+            resources:
+              requests:
+                storage: 1Gi
+      when: not cluster_info.volumepopulator_supported
+
+    - name: Verify contents of block PVC
+      include_role:
+        name: compare_pvc_data_block
+      vars:
+        pvc1_name: data-source
+        pvc2_name: data-dest
+        timeout: 900

--- a/test-e2e/test_rsync_tls_priv_diskrsync.yml
+++ b/test-e2e/test_rsync_tls_priv_diskrsync.yml
@@ -1,0 +1,197 @@
+---
+- hosts: localhost
+  tags:
+    - e2e
+    - rsync_tls
+    - diskrsync
+    - block
+    - privileged
+    - volumepopulator
+  tasks:
+    - name: Create namespace
+      include_role:
+        name: create_namespace
+
+    - include_role:
+        name: gather_cluster_info
+
+    - name: Enable privileged movers
+      include_role:
+        name: enable_privileged_mover
+
+    - name: Create dest block PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-dest-temp
+            namespace: "{{ namespace }}"
+          spec:
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Create ReplicationDestination
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: test
+            namespace: "{{ namespace }}"
+          spec:
+            rsyncTLS:
+              destinationPVC: data-dest-temp
+              copyMethod: Snapshot
+              capacity: 1Gi
+              accessModes:
+                - ReadWriteOnce
+
+    - name: Create source block PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-source
+            namespace: "{{ namespace }}"
+          spec:
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Write data into the source block PVC
+      include_role:
+        name: write_to_pvc_block
+      vars:
+        data: 'data'
+        pvc_name: 'data-source'
+
+    - name: Wait for key and address to be ready
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: test
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.rsyncTLS is defined and
+        res.resources[0].status.rsyncTLS.keySecret is defined and
+        res.resources[0].status.rsyncTLS.address is defined
+      delay: 1
+      retries: 300
+
+    - name: Create ReplicationSource
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              schedule: "0 0 1 1 *"
+            rsyncTLS:
+              keySecret: "{{ res.resources[0].status.rsyncTLS.keySecret }}"
+              address: "{{ res.resources[0].status.rsyncTLS.address }}"
+              copyMethod: Snapshot
+
+    - name: Check status of replicationsource
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationSource
+        name: source
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastSyncDuration is defined and
+        res.resources[0].status.lastSyncTime is defined and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful" and
+        res.resources[0].status.latestMoverStatus.logs is search("diskrsync completed in.*")
+      delay: 1
+      retries: 900
+      # res.resources[0].status.latestMoverStatus.logs is search("sent.*bytes.*received.*bytes.*") and
+
+    - name: Wait for sync to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: test
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.latestImage is defined and
+        res.resources[0].status.latestImage.kind == "VolumeSnapshot" and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful"
+      delay: 1
+      retries: 900
+
+    - name: Convert latestImage to PVC using VolumePopulator
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: data-dest
+            namespace: "{{ namespace }}"
+          spec:
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+            dataSourceRef:
+              kind: ReplicationDestination
+              apiGroup: volsync.backube
+              name: test
+            resources:
+              requests:
+                storage: 1Gi
+      when: cluster_info.volumepopulator_supported
+
+    - name: Convert latestImage to block PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: data-dest
+            namespace: "{{ namespace }}"
+          spec:
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+            dataSource:
+              kind: VolumeSnapshot
+              apiGroup: snapshot.storage.k8s.io
+              name: "{{ res.resources[0].status.latestImage.name }}"
+            resources:
+              requests:
+                storage: 1Gi
+      when: not cluster_info.volumepopulator_supported
+
+    - name: Verify contents of block PVC
+      include_role:
+        name: compare_pvc_data_block
+      vars:
+        pvc1_name: data-source
+        pvc2_name: data-dest
+        timeout: 900

--- a/test-e2e/test_simple_rsync_diskrsync.yml
+++ b/test-e2e/test_simple_rsync_diskrsync.yml
@@ -1,0 +1,190 @@
+---
+- hosts: localhost
+  tags:
+    - e2e
+    - rsync
+    - diskrsync
+    - block
+    - volumepopulator
+  tasks:
+    - include_role:
+        name: create_namespace
+
+    - include_role:
+        name: gather_cluster_info
+
+    - name: Create dest block PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-dest-temp
+            namespace: "{{ namespace }}"
+          spec:
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Create ReplicationDestination
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationDestination
+          metadata:
+            name: test
+            namespace: "{{ namespace }}"
+          spec:
+            rsync:
+              destinationPVC: data-dest-temp
+              copyMethod: Snapshot
+              capacity: 1Gi
+              accessModes:
+                - ReadWriteOnce
+
+    - name: Create source block PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data-source
+            namespace: "{{ namespace }}"
+          spec:
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+
+    - name: Write data into the source block PVC
+      include_role:
+        name: write_to_pvc_block
+      vars:
+        data: 'data'
+        pvc_name: 'data-source'
+
+    - name: Wait for ssh keys and address to be ready
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: test
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.rsync is defined and
+        res.resources[0].status.rsync.sshKeys is defined and
+        res.resources[0].status.rsync.address is defined
+      delay: 1
+      retries: 300
+
+    - name: Create ReplicationSource
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: volsync.backube/v1alpha1
+          kind: ReplicationSource
+          metadata:
+            name: source
+            namespace: "{{ namespace }}"
+          spec:
+            sourcePVC: data-source
+            trigger:
+              schedule: "0 0 1 1 *"
+            rsync:
+              sshKeys: "{{ res.resources[0].status.rsync.sshKeys }}"
+              address: "{{ res.resources[0].status.rsync.address }}"
+              copyMethod: Snapshot
+
+    - name: Check status of replicationsource
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationSource
+        name: source
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.lastSyncDuration is defined and
+        res.resources[0].status.lastSyncTime is defined and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful" and
+        res.resources[0].status.latestMoverStatus.logs is search("Rsync completed in.*")
+      delay: 1
+      retries: 900
+
+    - name: Wait for sync to complete
+      kubernetes.core.k8s_info:
+        api_version: volsync.backube/v1alpha1
+        kind: ReplicationDestination
+        name: test
+        namespace: "{{ namespace }}"
+      register: res
+      until: >
+        res.resources | length > 0 and
+        res.resources[0].status.latestImage is defined and
+        res.resources[0].status.latestImage.kind == "VolumeSnapshot" and
+        res.resources[0].status.latestMoverStatus is defined and
+        res.resources[0].status.latestMoverStatus.result == "Successful"
+      delay: 1
+      retries: 900
+
+    - name: Convert latestImage to block PVC using VolumePopulator
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: data-dest
+            namespace: "{{ namespace }}"
+          spec:
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+            dataSourceRef:
+              kind: ReplicationDestination
+              apiGroup: volsync.backube
+              name: test
+            resources:
+              requests:
+                storage: 1Gi
+      when: cluster_info.volumepopulator_supported
+
+    - name: Convert latestImage to block PVC
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: data-dest
+            namespace: "{{ namespace }}"
+          spec:
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+            dataSource:
+              kind: VolumeSnapshot
+              apiGroup: snapshot.storage.k8s.io
+              name: "{{ res.resources[0].status.latestImage.name }}"
+            resources:
+              requests:
+                storage: 1Gi
+      when: not cluster_info.volumepopulator_supported
+
+    - name: Verify contents of block PVC
+      include_role:
+        name: compare_pvc_data_block
+      vars:
+        pvc1_name: data-source
+        pvc2_name: data-dest
+        timeout: 900


### PR DESCRIPTION
@awels What do you think about the following update to your PR?  Creating a PR against your branch so you can see it first.

- Added some e2e tests - note there are issues running this as-is in kind - specifically the csi-hostpath driver does allow for block devices, but there can be an issue with finding loop devices.  Additionally in non-privileged mode, if you don't set the GID to match the GID that will be assigned to the loopback device that test will fail.  However, I'd like to see it run in CI to see what happens.
- I also updated the .sh scripts just to add some debug in there (mostly so at startup we can easily see if it's block vs filsystem).
- Wondering if ultimately we want to add a field in the spec (particularly for replicationdestination) to be able to specify the volumeMode (to be able to set block and volsync creates the pvc) - Right now users need to know to pre-create the destination PVC in block mode to match their source.
